### PR TITLE
feat: use category ID instead of name for card filter in api

### DIFF
--- a/prayerapp/views.py
+++ b/prayerapp/views.py
@@ -126,7 +126,7 @@ class CardFilter(django_filters.FilterSet):
     class Meta:
         model = Card
         fields = {
-            "category__name": ["exact"],
+            "category__id": ["exact"],
             "category__genre": ["exact"],
         }
 


### PR DESCRIPTION
<!--- Provide a concise title summarizing your changes -->
Allow filtering by category ID instead of name

## Description
<!--- Describe your changes in detail -->

## Reason
<!--- What is the purpose of this change? -->
<!--- If these changes resolve an open issue, please link to the issue here -->
It is easier to keep track of the ID than the name in React

## How this has been tested
<!--- How did you test these changes? -->
<!--- If these changes require additional testing, please explain that here -->
the swagger-ui

## Types of changes
<!--- What types of changes does your code introduce? Mark each applicable box with an `x` -->
- [ ] New feature (adds functionality)
- [ ] Bug fix (fixes an issue)
- [x] Breaking changes (causes defects to existing pieces)

## Screenshots

## Checklist:
<!--- Examine all of the following items and mark each applicable box with an `x` -->
- [x] I have read and complied with the **CONTRIBUTING** document
- [x] The changes I've made follow the existing code style and formatting requirements
- [x] My changes require updates to the documentation, which I have modified accordingly
