### PR TITLE
fix: add regex replace to remove strong's numbers from verses

### DIFF
--- a/prayerapp/management/commands/load_bible.py
+++ b/prayerapp/management/commands/load_bible.py
@@ -53,6 +53,9 @@ class Command(BaseCommand):
                         book = zip_match.group(1)
                         chapter = int(zip_match.group(2))
                         text = file.read().decode("utf-8")
+                        # Find and replace Strong's numbers
+                        strongs_pattern = r'|strong=".*"|\|'
+                        text = re.sub(strongs_pattern, "", text)
                         verse = 0
                         for line in text.splitlines()[2:]:
                             verse += 1

--- a/prayerapp/management/commands/load_bible.py
+++ b/prayerapp/management/commands/load_bible.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
                         chapter = int(zip_match.group(2))
                         text = file.read().decode("utf-8")
                         # Find and replace Strong's numbers
-                        strongs_pattern = r'|strong=".*"|\|'
+                        strongs_pattern = r'\|strong=".*"'
                         text = re.sub(strongs_pattern, "", text)
                         verse = 0
                         for line in text.splitlines()[2:]:


### PR DESCRIPTION
Remove Strong's Numbers.

## Description
A couple lines were added to the load_bible command that replaces instances of `|strong=".*"` in the text.

## Reason
#64 

## How this has been tested
Tested by deleting and recreating database with new script. 
No instances of the Strong's numbers were found when searching the api endpoint

## Types of changes
<!--- What types of changes does your code introduce? Mark each applicable box with an `x` -->
- [ ] New feature (adds functionality)
- [x] Bug fix (fixes an issue)
- [ ] Breaking changes (causes defects to existing pieces)

## Screenshots

## Checklist:
<!--- Examine all of the following items and mark each applicable box with an `x` -->
- [x] I have read and complied with the **CONTRIBUTING** document
- [x] The changes I've made follow the existing code style and formatting requirements
- [x] My changes require updates to the documentation, which I have modified accordingly
