### PR TITLE
fix: switch cards request to use category id instead of name

### DIFF
--- a/scriptured-prayer-components/src/App.tsx
+++ b/scriptured-prayer-components/src/App.tsx
@@ -19,7 +19,7 @@ const getRouter = (language: string) =>
         children: [
           { path: "/settings", element: <Settings /> },
           { path: "/home", element: <Home /> },
-          { path: "/prayer-decks/:name", element: <PrayerDeck /> },
+          { path: "/prayer-decks/:id", element: <PrayerDeck /> },
         ],
       },
       { path: "*", element: <NotFound /> },

--- a/scriptured-prayer-components/src/api/models/requests/CardsRequest.ts
+++ b/scriptured-prayer-components/src/api/models/requests/CardsRequest.ts
@@ -1,7 +1,7 @@
-import { CategoryGenre, CategoryName } from "~/types";
+import { CategoryGenre } from "~/types";
 
 export interface CardsRequest {
   category__genre?: keyof typeof CategoryGenre;
-  category__name?: CategoryName;
+  category__id?: number;
   limit?: number;
 }

--- a/scriptured-prayer-components/src/components/PrayerDeck.tsx
+++ b/scriptured-prayer-components/src/components/PrayerDeck.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
 import { Button, Flex, Heading } from "@radix-ui/themes";
 import { CheckIcon } from "@radix-ui/react-icons";
 import { Swiper, SwiperSlide } from "swiper/react";
@@ -9,26 +8,29 @@ import "swiper/css/navigation";
 import "swiper/css/pagination";
 
 import "~/swiper.css";
-import { useApi } from "~/hooks";
+import { useApi, useRouteId } from "~/hooks";
 import { CardResponse } from "~/api/models/responses";
 import { Card } from "./Card";
 
 function PrayerDeck() {
   const api = useApi();
-  const { name } = useParams();
+  const id = useRouteId();
   const [cards, setCards] = useState<CardResponse[]>([]);
 
   useEffect(() => {
-    (async () => {
-      api.cards
-        .all({ category__name: name })
-        .then((cards) => {
-          setCards(cards);
-          console.log(cards);
-        })
-        .catch((error) => console.error(error));
-    })();
+    if (id) {
+      (async () => {
+        api.cards
+          .all({ category__id: id })
+          .then((cards) => {
+            setCards(cards);
+          })
+          .catch((error) => console.error(error));
+      })();
+    }
   }, []);
+
+  if (!id) return <>Error: an id must be provided.</>;
 
   return (
     <div className="bg-ocean h-full">

--- a/scriptured-prayer-components/src/hooks/index.ts
+++ b/scriptured-prayer-components/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export * from "./useApi";
 export * from "./useLocalStorage";
 export * from "./useProfile";
+export * from "./useRouteId";

--- a/scriptured-prayer-components/src/hooks/useRouteId.tsx
+++ b/scriptured-prayer-components/src/hooks/useRouteId.tsx
@@ -1,0 +1,16 @@
+import { useEffect } from "react";
+import { useParams } from "react-router-dom";
+
+const validateId = (id: string | undefined) =>
+  !id || isNaN(+id) || +id < 1 ? null : +id;
+
+export function useRouteId() {
+  const { id } = useParams();
+  const parsed = validateId(id);
+
+  useEffect(() => {
+    if (!parsed) console.error("An id was not provided.");
+  }, [parsed]);
+
+  return parsed;
+}

--- a/scriptured-prayer-components/src/types/CategoryName.ts
+++ b/scriptured-prayer-components/src/types/CategoryName.ts
@@ -1,1 +1,0 @@
-export type CategoryName = string;

--- a/scriptured-prayer-components/src/types/index.ts
+++ b/scriptured-prayer-components/src/types/index.ts
@@ -1,4 +1,3 @@
 export * from "./Profile";
 export * from "./Storage";
 export * from "./CategoryGenre";
-export * from "./CategoryName";

--- a/scriptured-prayer-components/src/views/Home.tsx
+++ b/scriptured-prayer-components/src/views/Home.tsx
@@ -67,7 +67,7 @@ export function Home() {
                   image={deckImages[i]}
                   color={deckColors[i]}
                   // todo: use an id instead of category name to retrieve cards
-                  onClick={() => navigate(`/prayer-decks/${category.name}`)}
+                  onClick={() => navigate(`/prayer-decks/${category.id}`)}
                 />
               ))}
             </div>


### PR DESCRIPTION
## Description
Switch the cards API request inside `PrayerDeck.tsx` to use `category__id` instead of `category__name`.

## Reason
The changes applied by #70 broke the Prayer Deck page. These changes resolve the issue so that API requests can be made using the supplied category ID rather than name.

## How this has been tested
Locally, via the Yarn build.

## Types of changes
- [ ] New feature (adds functionality)
- [x] Bug fix (fixes an issue)
- [ ] Breaking changes (causes defects to existing pieces)

## Screenshots

## Checklist:
- [x] I have read and complied with the **CONTRIBUTING** document
- [x] The changes I've made follow the existing code style and formatting requirements
- [ ] My changes require updates to the documentation, which I have modified accordingly
