### PR TITLE
feat: hard code links to Prayer Decks on Info view

### DIFF
--- a/scriptured-prayer-components/src/App.tsx
+++ b/scriptured-prayer-components/src/App.tsx
@@ -14,12 +14,12 @@ const getRouter = (language: string) =>
       { path: "/", element: <Info /> },
       { path: "/login", element: <Login /> },
       { path: "/about", element: <About /> },
+      { path: "/prayer-decks/:id", element: <PrayerDeck /> },
       {
         element: <ProtectedRoutes />,
         children: [
           { path: "/settings", element: <Settings /> },
           { path: "/home", element: <Home /> },
-          { path: "/prayer-decks/:id", element: <PrayerDeck /> },
         ],
       },
       { path: "*", element: <NotFound /> },

--- a/scriptured-prayer-components/src/hooks/index.ts
+++ b/scriptured-prayer-components/src/hooks/index.ts
@@ -2,3 +2,4 @@ export * from "./useApi";
 export * from "./useLocalStorage";
 export * from "./useProfile";
 export * from "./useRouteId";
+export * from "./useDemoPrayerDecks";

--- a/scriptured-prayer-components/src/hooks/useDemoPrayerDecks.tsx
+++ b/scriptured-prayer-components/src/hooks/useDemoPrayerDecks.tsx
@@ -1,0 +1,64 @@
+import { DemoPrayerDeck } from "~/types";
+import forest from "~/assets/images/forest.jpg";
+import mountains from "~/assets/images/mountains.jpg";
+import clouds from "~/assets/images/clouds.jpg";
+import galaxy from "~/assets/images/galaxy.jpg";
+import dryGrass from "~/assets/images/dry-grass.jpg";
+import readingBible from "~/assets/images/reading-bible.jpg";
+
+// todo: retrieve this data from an endpoint
+const demoPrayerDecks: DemoPrayerDeck[][] = [
+  [
+    {
+      title: "God Is",
+      description: '"God" is verses act as a checkup for your relationship...',
+      image: forest,
+      color: "olive",
+      id: 2,
+    },
+    {
+      title: "In Christ",
+      description: "When we become Christians, it's not simply a label...",
+      image: dryGrass,
+      color: "indigo",
+      id: 5,
+    },
+    {
+      title: "Promises of God",
+      description: "Believing God's promises is how the men and women...",
+      image: readingBible,
+      color: "sky",
+      id: 6,
+    },
+  ],
+  [
+    {
+      title: "Names of God",
+      description: "Look upon God and grow in love with Him...",
+      image: mountains,
+      color: "ocean",
+      id: 1,
+    },
+    {
+      title: "Names of Jesus",
+      description:
+        "Meditate on the names of Jesus and see the overflow of God’s heart...",
+      image: galaxy,
+      color: "obsidian",
+      id: 3,
+    },
+    {
+      title: "Names of the Holy Spirit",
+      description:
+        "When you meditate on these verses and see what the Spirit does for you...",
+      image: clouds,
+      color: "leaf",
+      id: 4,
+    },
+  ],
+];
+
+// temporarily simulate the async call to our demo prayer decks api endpoint.
+export async function useDemoPrayerDecks(): Promise<DemoPrayerDeck[][]> {
+  return Promise.resolve(demoPrayerDecks);
+}

--- a/scriptured-prayer-components/src/index.css
+++ b/scriptured-prayer-components/src/index.css
@@ -12,6 +12,7 @@ html {
 
 html,
 body {
+  background-color: var(--color-page-background);
   display: flex;
   flex-direction: column;
 }

--- a/scriptured-prayer-components/src/types/DemoPrayerDeck.ts
+++ b/scriptured-prayer-components/src/types/DemoPrayerDeck.ts
@@ -1,0 +1,9 @@
+import { theme } from "~/tailwind.config";
+
+export interface DemoPrayerDeck {
+  title: string;
+  description: string;
+  image: string;
+  color: keyof typeof theme.colors;
+  id: number;
+}

--- a/scriptured-prayer-components/src/types/index.ts
+++ b/scriptured-prayer-components/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from "./Profile";
 export * from "./Storage";
 export * from "./CategoryGenre";
+export * from "./DemoPrayerDeck";

--- a/scriptured-prayer-components/src/views/Info.tsx
+++ b/scriptured-prayer-components/src/views/Info.tsx
@@ -1,30 +1,25 @@
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import forest from "~/assets/images/forest.jpg";
-import mountains from "~/assets/images/mountains.jpg";
-import clouds from "~/assets/images/clouds.jpg";
-import galaxy from "~/assets/images/galaxy.jpg";
-import dryGrass from "~/assets/images/dry-grass.jpg";
-import readingBible from "~/assets/images/reading-bible.jpg";
-
-import { theme } from "~/tailwind.config";
-
-// todo: delete this. it is just a placeholder
-const deckImages = [mountains, forest, galaxy, clouds, dryGrass, readingBible];
-
-const deckColors: (keyof typeof theme.colors)[] = [
-  "ocean",
-  "olive",
-  "obsidian",
-  "leaf",
-  "indigo",
-  "sky",
-];
-
 import { Deck } from "~/components";
+import { DemoPrayerDeck } from "~/types";
+import { useDemoPrayerDecks } from "~/hooks";
+import forest from "~/assets/images/forest.jpg";
 
 export function Info() {
   const navigate = useNavigate();
+  const demoPrayerDecks = useDemoPrayerDecks();
+  const [prayerDecks, setPrayerDecks] = useState<DemoPrayerDeck[][]>([]);
+
+  useEffect(() => {
+    (async () => {
+      demoPrayerDecks
+        .then((decks) => {
+          setPrayerDecks(decks);
+        })
+        .catch((error) => console.error(error));
+    })();
+  }, []);
 
   return (
     <>
@@ -96,66 +91,23 @@ export function Info() {
         </div>
       </div>
       <div className="bg-lichen">
-        <div className="px-6 pt-8  md:space-x-12 max-w-screen-xl mx-auto">
-          <div className="flex flex-col lg:flex-row w-full lg:space-x-12 justify-center ">
-            <Deck
-              title="God Is"
-              description={
-                '"God" is verses act as a checkup for your relationship...'
-              }
-              image={deckImages[2 - 1]}
-              color={deckColors[2 - 1]}
-              scaleOnHover
-              onClick={() => navigate("/prayer-decks/2")}
-            />
-            <Deck
-              title="In Christ"
-              description="When we become Christians, it's not simply a label..."
-              image={deckImages[5 - 1]}
-              color={deckColors[5 - 1]}
-              scaleOnHover
-              onClick={() => navigate("/prayer-decks/5")}
-            />
-            <Deck
-              title="Promises of God"
-              description="Believing God's promises is how the men and women..."
-              image={deckImages[6 - 1]}
-              color={deckColors[6 - 1]}
-              scaleOnHover
-              onClick={() => navigate("/prayer-decks/6")}
-            />
+        {prayerDecks.map((row, i) => (
+          <div
+            key={i}
+            className="px-6 pt-8  md:space-x-12 max-w-screen-xl mx-auto"
+          >
+            <div className="flex flex-col lg:flex-row w-full lg:space-x-12 justify-center">
+              {row.map(({ id, ...c }, j) => (
+                <Deck
+                  key={j}
+                  {...c}
+                  scaleOnHover
+                  onClick={() => navigate(`/prayer-decks/${id}`)}
+                />
+              ))}
+            </div>
           </div>
-        </div>
-        <div className="px-6 pb-8 md:py-8 md:space-x-12 max-w-screen-xl mx-auto">
-          <div className="flex flex-col lg:flex-row w-full lg:space-x-12 justify-center ">
-            <Deck
-              title="Names of God"
-              description="Look upon God and grow in love with Him..."
-              image={deckImages[1 - 1]}
-              color={deckColors[1 - 1]}
-              scaleOnHover
-              onClick={() => navigate("/prayer-decks/1")}
-            />
-
-            <Deck
-              title="Names of Jesus"
-              description="Meditate on the names of Jesus and see the overflow of God’s heart..."
-              image={deckImages[3 - 1]}
-              color={deckColors[3 - 1]}
-              scaleOnHover
-              onClick={() => navigate("/prayer-decks/3")}
-            />
-
-            <Deck
-              title="Names of the Holy Spirit"
-              description="When you meditate on these verses and see what the Spirit does for you..."
-              image={deckImages[4 - 1]}
-              color={deckColors[4 - 1]}
-              scaleOnHover
-              onClick={() => navigate("/prayer-decks/4")}
-            />
-          </div>
-        </div>
+        ))}
       </div>
     </>
   );

--- a/scriptured-prayer-components/src/views/Info.tsx
+++ b/scriptured-prayer-components/src/views/Info.tsx
@@ -4,6 +4,23 @@ import forest from "~/assets/images/forest.jpg";
 import mountains from "~/assets/images/mountains.jpg";
 import clouds from "~/assets/images/clouds.jpg";
 import galaxy from "~/assets/images/galaxy.jpg";
+import dryGrass from "~/assets/images/dry-grass.jpg";
+import readingBible from "~/assets/images/reading-bible.jpg";
+
+import { theme } from "~/tailwind.config";
+
+// todo: delete this. it is just a placeholder
+const deckImages = [mountains, forest, galaxy, clouds, dryGrass, readingBible];
+
+const deckColors: (keyof typeof theme.colors)[] = [
+  "ocean",
+  "olive",
+  "obsidian",
+  "leaf",
+  "indigo",
+  "sky",
+];
+
 import { Deck } from "~/components";
 
 export function Info() {
@@ -79,33 +96,63 @@ export function Info() {
         </div>
       </div>
       <div className="bg-lichen">
-        <div className="px-6 py-8 md:py-16 md:space-x-12 max-w-screen-xl mx-auto">
-          <div className="flex flex-col lg:flex-row w-full lg:space-x-12 justify-between">
+        <div className="px-6 pt-8  md:space-x-12 max-w-screen-xl mx-auto">
+          <div className="flex flex-col lg:flex-row w-full lg:space-x-12 justify-center ">
             <Deck
               title="God Is"
               description={
                 '"God" is verses act as a checkup for your relationship...'
               }
-              image={mountains}
-              color="stone"
+              image={deckImages[2 - 1]}
+              color={deckColors[2 - 1]}
               scaleOnHover
-              onClick={() => navigate("/home")}
+              onClick={() => navigate("/prayer-decks/2")}
             />
             <Deck
               title="In Christ"
               description="When we become Christians, it's not simply a label..."
-              image={clouds}
-              color="leaf"
+              image={deckImages[5 - 1]}
+              color={deckColors[5 - 1]}
               scaleOnHover
-              onClick={() => navigate("/home")}
+              onClick={() => navigate("/prayer-decks/5")}
             />
             <Deck
               title="Promises of God"
               description="Believing God's promises is how the men and women..."
-              image={galaxy}
-              color="obsidian"
+              image={deckImages[6 - 1]}
+              color={deckColors[6 - 1]}
               scaleOnHover
-              onClick={() => navigate("/home")}
+              onClick={() => navigate("/prayer-decks/6")}
+            />
+          </div>
+        </div>
+        <div className="px-6 pb-8 md:py-8 md:space-x-12 max-w-screen-xl mx-auto">
+          <div className="flex flex-col lg:flex-row w-full lg:space-x-12 justify-center ">
+            <Deck
+              title="Names of God"
+              description="Look upon God and grow in love with Him..."
+              image={deckImages[1 - 1]}
+              color={deckColors[1 - 1]}
+              scaleOnHover
+              onClick={() => navigate("/prayer-decks/1")}
+            />
+
+            <Deck
+              title="Names of Jesus"
+              description="Meditate on the names of Jesus and see the overflow of God’s heart..."
+              image={deckImages[3 - 1]}
+              color={deckColors[3 - 1]}
+              scaleOnHover
+              onClick={() => navigate("/prayer-decks/3")}
+            />
+
+            <Deck
+              title="Names of the Holy Spirit"
+              description="When you meditate on these verses and see what the Spirit does for you..."
+              image={deckImages[4 - 1]}
+              color={deckColors[4 - 1]}
+              scaleOnHover
+              onClick={() => navigate("/prayer-decks/4")}
             />
           </div>
         </div>


### PR DESCRIPTION
# Allow Guest Access to Prayer Decks

## Description
Removed prayer decks from protected routes to allow guest access. This gives guest (un-authenticated) users access to the 6 pre-made prayer decks.

## Reason
Guest access to the pre-made decks is a requirement in the MVP and supports Follin's demo this week.  

## How this has been tested
I browsed the home page while running the latest backend and frontend build. 

## Types of changes
- [x] New feature (adds functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking changes (causes defects to existing pieces)

## Screenshots
<img width="1363" alt="prayer-decks" src="https://github.com/PrayTeam/scriptured-prayer/assets/315883/3d3ff38b-91ad-4180-8138-cc34fe923491">

## Checklist:
<!--- Examine all of the following items and mark each applicable box with an `x` -->
- [x] I have read and complied with the **CONTRIBUTING** document
- [x] The changes I've made follow the existing code style and formatting requirements
- [ ] My changes require updates to the documentation, which I have modified accordingly
