### PR TITLE
feat: restore local husky install whilst ignoring in production workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Run yarn install
       uses: borales/actions-yarn@v5
       with:
-        cmd: install
+        cmd: install --production --ignore-scripts
         dir: scriptured-prayer-components
   
     - name: Run yarn build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Run yarn install
       uses: borales/actions-yarn@v5
       with:
-        cmd: install --production --ignore-scripts
+        cmd: install --ignore-scripts
         dir: scriptured-prayer-components
   
     - name: Run yarn build

--- a/scriptured-prayer-components/package.json
+++ b/scriptured-prayer-components/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "rimraf ../prayerapp/static/prayerapp && tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "postinstall": "cd .. && husky install",
     "preview": "vite preview"
   },
   "lint-staged": {


### PR DESCRIPTION
## Description
Effectively reverts #82 for **local installs**, with the caveat explained below.

## Reason
Husky is an important piece of the local development workflow; the `postinstall` script is for the purpose of preventing accidental Yarn installs from the `scriptured-prayer-components` directory skipping husky and the hooks that it installs for us (currently `commit-msg` and `pre-commit`).

## How this has been tested
Running the below:
```sh
$ yarn install --production --ignore-scripts
```
successfully skips the husky postinstall step and yields the following:
```sh
warning Ignored scripts due to flag.
Done in 1.09s.
```

## Types of changes
- [x] New feature (adds functionality)
- [ ] Bug fix (fixes an issue)
- [ ] Breaking changes (causes defects to existing pieces)

## Screenshots
N/A

## Checklist:
- [x] I have read and complied with the **CONTRIBUTING** document
- [x] The changes I've made follow the existing code style and formatting requirements
- [ ] My changes require updates to the documentation, which I have modified accordingly
