### PR TITLE
fix: remove reference to localhost in production env

### DIFF
--- a/scriptured-prayer-components/.env.production
+++ b/scriptured-prayer-components/.env.production
@@ -1,1 +1,1 @@
-VITE_PRAYERAPP_API="http://localhost:8000"
+VITE_PRAYERAPP_API=""


### PR DESCRIPTION
## Description
Remove erroneous reference to localhost in the production .env file.

## Reason
The .env file used for deployment contained a reference to localhost that was causing API requests to fail.

## How this has been tested
Locally via the project build.

## Types of changes
- [ ] New feature (adds functionality)
- [x] Bug fix (fixes an issue)
- [ ] Breaking changes (causes defects to existing pieces)

## Screenshots
N/A

## Checklist:
- [x] I have read and complied with the **CONTRIBUTING** document
- [x] The changes I've made follow the existing code style and formatting requirements
- [ ] My changes require updates to the documentation, which I have modified accordingly
