### PR TITLE
fix: swagger using wrong schema url

### DIFF
--- a/prayerapp/dev_urls.py
+++ b/prayerapp/dev_urls.py
@@ -11,12 +11,12 @@ urlpatterns = [
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path(
         "api/schema/swagger-ui/",
-        SpectacularSwaggerView.as_view(url_name="prayerappdev:swagger"),
+        SpectacularSwaggerView.as_view(url_name="schema"),
         name="swagger-ui",
     ),
     path(
         "api/schema/redoc/",
-        SpectacularRedocView.as_view(url_name="prayerappdev:redoc"),
+        SpectacularRedocView.as_view(url_name="schema"),
         name="redoc",
     ),
 ] + urlpatterns


### PR DESCRIPTION
<!--- Provide a concise title summarizing your changes -->
Seems I broke swagger when I moved dev settings out of settings.py.

## Description
<!--- Describe your changes in detail -->
Update the drf_spectacular urls to use the correct schema.

## Reason
<!--- What is the purpose of this change? -->
<!--- If these changes resolve an open issue, please link to the issue here -->
Swagger doesn't work with the current dev settings.

## How this has been tested
<!--- How did you test these changes? -->
<!--- If these changes require additional testing, please explain that here -->
Manually.

## Types of changes
<!--- What types of changes does your code introduce? Mark each applicable box with an `x` -->
- [ ] New feature (adds functionality)
- [x] Bug fix (fixes an issue)
- [ ] Breaking changes (causes defects to existing pieces)

## Screenshots

## Checklist:
<!--- Examine all of the following items and mark each applicable box with an `x` -->
- [x] I have read and complied with the **CONTRIBUTING** document
- [x] The changes I've made follow the existing code style and formatting requirements
- [ ] My changes require updates to the documentation, which I have modified accordingly
