### PR TITLE
Feat/logging swipes

### DIFF
--- a/prayerapp/models.py
+++ b/prayerapp/models.py
@@ -211,7 +211,7 @@ class UserCardPrayedLog(models.Model):
     date_prayed = models.DateTimeField(_("date prayed"), blank=True, null=True, auto_now_add=True)
 
     def __str__(self) -> str:
-        return f"{self.usercard.user.username} - {self.usercard.card.title} in prayer on {self.prayerdeck.date}"
+        return f"{self.usercard.user.username} - {self.usercard.card.title} in prayer on {self.date_prayed}"
 
 
 class CardScriptureJson(models.Model):

--- a/prayerapp/views.py
+++ b/prayerapp/views.py
@@ -92,6 +92,7 @@ class UserCardFilter(django_filters.FilterSet):
         fields = {
             "card__category__name": ["exact"],
             "card__category__genre": ["exact"],
+            "card__category__id": ["exact"],
             "answered": ["exact"],
             "hidden": ["exact"],
             "in_prayer_deck": ["exact"],

--- a/scriptured-prayer-components/src/api/models/requests/UserCardsRequest.ts
+++ b/scriptured-prayer-components/src/api/models/requests/UserCardsRequest.ts
@@ -1,0 +1,8 @@
+import { CategoryGenre } from "~/types";
+
+export interface UserCardsRequest {
+  card__category__id?: number;
+  card__category__genre?: keyof typeof CategoryGenre;
+  card__category__name?: string;
+  limit?: number;
+}

--- a/scriptured-prayer-components/src/api/models/requests/index.ts
+++ b/scriptured-prayer-components/src/api/models/requests/index.ts
@@ -1,2 +1,3 @@
 export * from "./LoginRequest";
 export * from "./CardsRequest";
+export * from "./UserCardsRequest";

--- a/scriptured-prayer-components/src/api/models/responses/UserCardResponse.ts
+++ b/scriptured-prayer-components/src/api/models/responses/UserCardResponse.ts
@@ -6,18 +6,18 @@ interface ScriptureText {
 }
 
 export interface UserCardResponse {
-  id: number;
-  title: string;
-  scripture: string;
-  version: string;
-  scripture_text: ScriptureText[];
-  descriptions: string;
-  copyright_notice: string;
-  category: string;
-  genre: string;
-  usercardnote_set: [];
   answered: boolean;
+  category: string;
+  copyright_notice: string;
+  description: string;
+  genre: string;
   hidden: boolean;
+  id: number;
   in_prayer_deck: boolean;
-  last_prayed: Date | null;
+  instruction: string;
+  scripture: string;
+  scripture_text: ScriptureText[];
+  title: string;
+  usercardnote_set: string[];
+  version: string;
 }

--- a/scriptured-prayer-components/src/components/Card.tsx
+++ b/scriptured-prayer-components/src/components/Card.tsx
@@ -1,7 +1,7 @@
 import { Badge, Text } from "@radix-ui/themes";
-import { CardResponse } from "~/api/models/responses";
+import { CardResponse, UserCardResponse } from "~/api/models/responses";
 
-export function Card(props: CardResponse) {
+export function Card(props: CardResponse | UserCardResponse) {
   return (
     <div className="bg-white h-50 py-8 md:py-12 px-6 md:px-16 rounded-md">
       <Badge

--- a/scriptured-prayer-components/src/components/PrayerDeck.tsx
+++ b/scriptured-prayer-components/src/components/PrayerDeck.tsx
@@ -15,8 +15,7 @@ import { Card } from "./Card";
 function PrayerDeck() {
   const api = useApi();
   const id = useRouteId();
-  const [cards, setCards] = useState<CardResponse[]>([]);
-  const [userCards, setUserCards] = useState<UserCardResponse[]>([]);
+  const [cards, setCards] = useState<CardResponse[] | UserCardResponse[]>([]);
   const { profile } = useProfile();
   const [activeCardId, setActiveCardId] = useState<number>();
 
@@ -27,12 +26,9 @@ function PrayerDeck() {
           ? api.userCards
               .all({ card__category__id: id })
               .then((userCards) => {
-                setUserCards(userCards);
-                setActiveCardId(userCards[0].id);
+                setCards(userCards);
+                setActiveCardId(cards[0].id);
                 return userCards;
-              })
-              .then((userCards) => {
-                console.log(userCards);
               })
               .catch((error) => console.error(error))
           : api.cards
@@ -73,17 +69,11 @@ function PrayerDeck() {
               : () => {}
           }
         >
-          {profile && profile.authenticated
-            ? userCards.map((userCard) => (
-                <SwiperSlide key={userCard.id} data-id={userCard.id}>
-                  <Card {...userCard} />
-                </SwiperSlide>
-              ))
-            : cards.map((card) => (
-                <SwiperSlide key={card.id} data-id={card.id}>
-                  <Card {...card} />
-                </SwiperSlide>
-              ))}
+          {cards.map((card) => (
+            <SwiperSlide key={card.id} data-id={card.id}>
+              <Card {...card} />
+            </SwiperSlide>
+          ))}
         </Swiper>
 
         <Button size="4" className="w-80 mx-auto mt-4 bg-lichen">

--- a/scriptured-prayer-components/src/hooks/useApi.tsx
+++ b/scriptured-prayer-components/src/hooks/useApi.tsx
@@ -105,7 +105,8 @@ export function useApi() {
           parameterizeRequest("usercards/", userCardsRequest),
           withCsrf(options),
         ),
-      logCard: (pk: number) => post(`usercards/?pk=${pk}`, withCsrf(options)),
+      logCard: (pk: number) =>
+        post(`usercards/${pk}/log_prayer/`, withCsrf(options)),
     },
   };
 }

--- a/scriptured-prayer-components/src/hooks/useApi.tsx
+++ b/scriptured-prayer-components/src/hooks/useApi.tsx
@@ -1,7 +1,11 @@
 import Cookies from "js-cookie";
 
 import { Profile } from "~/types";
-import { CardsRequest, LoginRequest } from "~/api/models/requests";
+import {
+  CardsRequest,
+  LoginRequest,
+  UserCardsRequest,
+} from "~/api/models/requests";
 import {
   UserCardResponse,
   LogoutResponse,
@@ -96,7 +100,12 @@ export function useApi() {
       all: () => get<CategoryResponse[]>("categories/", options),
     },
     userCards: {
-      all: () => get<UserCardResponse[]>("usercards/?format=json", options),
+      all: (userCardsRequest?: UserCardsRequest) =>
+        get<UserCardResponse[]>(
+          parameterizeRequest("usercards/", userCardsRequest),
+          options,
+        ),
+      logCard: (pk: number) => post(`usercards/?pk=${pk}`),
     },
   };
 }

--- a/scriptured-prayer-components/src/hooks/useApi.tsx
+++ b/scriptured-prayer-components/src/hooks/useApi.tsx
@@ -103,9 +103,9 @@ export function useApi() {
       all: (userCardsRequest?: UserCardsRequest) =>
         get<UserCardResponse[]>(
           parameterizeRequest("usercards/", userCardsRequest),
-          options,
+          withCsrf(options),
         ),
-      logCard: (pk: number) => post(`usercards/?pk=${pk}`),
+      logCard: (pk: number) => post(`usercards/?pk=${pk}`, withCsrf(options)),
     },
   };
 }


### PR DESCRIPTION
Logging Swipes for logged in users.

## Description
Added functionality to the PrayerDeck component to keep track of the current card's id and log each swipe if the user is authenticated. This included adding a new method to userCards in the useApi hook.

## Reason
Cards need to be logged when prayed to curate the daily decks for each user.
Related to #99 

## How this has been tested
I tested by swiping through the Names of God deck and checking the messages logged by the backend to ensure the server was receiving the correct requests. I also checked that new UserCardPrayed objects were being created in the database.
I also checked that users who weren't logged in could still access and swipe through the prayer deck

## Types of changes
<!--- What types of changes does your code introduce? Mark each applicable box with an `x` -->
- [x] New feature (adds functionality)
- [x] Bug fix (fixes an issue)
- [ ] Breaking changes (causes defects to existing pieces)

## Screenshots

## Checklist:
<!--- Examine all of the following items and mark each applicable box with an `x` -->
- [x] I have read and complied with the **CONTRIBUTING** document
- [x] The changes I've made follow the existing code style and formatting requirements
- [ ] My changes require updates to the documentation, which I have modified accordingly
