### PR TITLE
Remove the locale from the React app basename

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,7 +23,7 @@ function App() {
   return (
     <ProfileContext.Provider value={{ profile, setProfile }}>
       <Theme className="h-full">
-        <BrowserRouter basename={`/${profile.language}`}>
+        <BrowserRouter>
           <Routes>
             <Route path="/" element={<Home />} />
             <Route path="/login" element={<Login />} />

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -28,9 +28,9 @@ export function Footer({ color, text }: FooterProps) {
             <h2 className="font-semibold text-base">Useful Links</h2>
             <FooterLinks>
               {/* TODO: fix these links to work with Spanish */}
-              <FooterLink link="/en/about">About Us</FooterLink>
-              <FooterLink link="/en/info">Info</FooterLink>
-              <FooterLink link="/en/FAQ">FAQ</FooterLink>
+              <FooterLink link="/about">About Us</FooterLink>
+              <FooterLink link="/info">Info</FooterLink>
+              <FooterLink link="/FAQ">FAQ</FooterLink>
             </FooterLinks>
           </FooterColumn>
 
@@ -58,10 +58,7 @@ export function Footer({ color, text }: FooterProps) {
             © Copyright 2024. All Rights Reserved.
           </span>
           <span>
-            <FooterLink
-              link="/en/privacy"
-              className="text-gray hover:underline"
-            >
+            <FooterLink link="/privacy" className="text-gray hover:underline">
               Privacy Policy
             </FooterLink>
           </span>

--- a/frontend/src/components/Link.tsx
+++ b/frontend/src/components/Link.tsx
@@ -1,18 +1,11 @@
-import { useProfile } from "~/hooks";
-
 interface LinkProps {
   href: string;
   children: string;
 }
 
 export function Link(props: LinkProps) {
-  const { profile } = useProfile();
-
   return (
-    <a
-      className="underline text-emerald"
-      href={`/${profile.language}${props.href}`}
-    >
+    <a className="underline text-emerald" href={props.href}>
       {props.children}
     </a>
   );


### PR DESCRIPTION
## Description
Remove the locale requirement in the frontend's routing basename.

## Reason
To address API changes made as part of [release v0.8.0](https://github.com/PrayTeam/scriptured-prayer/releases/tag/v0.8.0).

## How this has been tested
Locally via accessing routes, e.g:

- /en/dashboard => /dashboard
- /en/search => /search

## Types of changes
- [ ] New feature (adds functionality)
- [x] Bug fix (fixes an issue)
- [ ] Breaking changes (causes defects to existing pieces)

## Screenshots

## Checklist:
- [x] I have read and complied with the **CONTRIBUTING** document
- [x] The changes I've made follow the existing code style and formatting requirements
- [ ] My changes require updates to the documentation, which I have modified accordingly
