### PR TITLE
fix: correct missing slash in static files path

### DIFF
--- a/scriptured_prayer/settings.py
+++ b/scriptured_prayer/settings.py
@@ -144,7 +144,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_URL = "/static/"
 STATIC_ROOT = os.environ.get("DJANGO_STATIC_ROOT","/var/www/html/staticfiles")
 
 STORAGES = {


### PR DESCRIPTION
## Description
The `STATIC_URL` path was missing a slash.

## Reason
To correct errors regarding failure to resolve assets in the static directory.

## How this has been tested
Locally.

## Types of changes
- [ ] New feature (adds functionality)
- [x] Bug fix (fixes an issue)
- [ ] Breaking changes (causes defects to existing pieces)

## Screenshots

## Checklist:
- [x] I have read and complied with the **CONTRIBUTING** document
- [x] The changes I've made follow the existing code style and formatting requirements
- [ ] My changes require updates to the documentation, which I have modified accordingly
