### PR TITLE
fix: correct missing basename on react router

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
 import "@radix-ui/themes/styles.css";
 import { Theme } from "@radix-ui/themes";
 
@@ -21,16 +21,15 @@ import { useLocalStorage, ProfileContext } from "./hooks";
 function App() {
   const [profile, setProfile] = useLocalStorage("profile");
 
+  if (window.location.pathname === "/")
+    window.location.replace(`/${profile.language}`);
+
   return (
     <ProfileContext.Provider value={{ profile, setProfile }}>
       <Theme className="flex flex-col h-full">
-        <BrowserRouter>
+        <BrowserRouter basename={`/${profile.language}`}>
           <Routes>
-            <Route
-              path="/"
-              element={<Navigate to={`/${profile.language}`} />}
-            />
-            <Route path={`/${profile.language}`} element={<Home />} />
+            <Route path="/" element={<Home />} />
             <Route path="/login" element={<Login />} />
             <Route path="/about" element={<About />} />
             <Route path="/privacy" element={<Privacy />} />

--- a/frontend/src/components/PrayerDeck.tsx
+++ b/frontend/src/components/PrayerDeck.tsx
@@ -107,7 +107,7 @@ export function PrayerDeck() {
                     </SwiperSlide>
                   ))}
                   <SwiperSlide>
-                    <div className="flex justify-center items-center">
+                    <div className="flex justify-center items-center h-full">
                       <Button
                         onClick={() => navigate("/dashboard")}
                         size="4"


### PR DESCRIPTION
## Description
The `basename` was missing from the React Router, causing issues with page reloads.

Edit: this also corrects a style change that didn't get added in #145.

## Reason
Restores the missing `basename` property on the React Router.

## How this has been tested
Locally: via the React frontend using yarn dev and the built binary via yarn build in conjunction with the Django API.

## Types of changes
- [ ] New feature (adds functionality)
- [x] Bug fix (fixes an issue)
- [ ] Breaking changes (causes defects to existing pieces)

## Screenshots

## Checklist:
- [x] I have read and complied with the **CONTRIBUTING** document
- [x] The changes I've made follow the existing code style and formatting requirements
- [ ] My changes require updates to the documentation, which I have modified accordingly
